### PR TITLE
Hotfix/wrong total price

### DIFF
--- a/includes/payment-methods/class-wc-gateway-braspag-creditcard.php
+++ b/includes/payment-methods/class-wc-gateway-braspag-creditcard.php
@@ -229,7 +229,8 @@ class WC_Gateway_Braspag_CreditCard extends WC_Gateway_Braspag
         $return = array();
         $installments++;
 
-        $grandTotal = WC()->cart->get_cart_contents_total();
+        //$grandTotal = WC()->cart->get_cart_contents_total();
+        $grandTotal = WC()->cart->get_total('edit');
 
         for ($i = 1; $i < $installments; $i++) {
             $installmentAmount = $grandTotal / $i;

--- a/includes/payment-methods/class-wc-gateway-braspag-creditcard.php
+++ b/includes/payment-methods/class-wc-gateway-braspag-creditcard.php
@@ -229,7 +229,6 @@ class WC_Gateway_Braspag_CreditCard extends WC_Gateway_Braspag
         $return = array();
         $installments++;
 
-        //$grandTotal = WC()->cart->get_cart_contents_total();
         $grandTotal = WC()->cart->get_total('edit');
 
         for ($i = 1; $i < $installments; $i++) {


### PR DESCRIPTION
**Problema Identificado**
Foi reportado que o cálculo do total do pedido no WooCommerce estava inconsistente entre o valor total exibido no checkout e o valor exibido no dropdown de parcelamento. Especificamente, quando a opção nativa de "Taxas/Impostos" estava habilitada e o pedido incluía frete, o valor do parcelamento no dropdown não refletia o total final com frete e impostos.

**Solução Implementada**
O problema foi diagnosticado como sendo causado pela função que calculava as parcelas, a qual considerava apenas o subtotal dos produtos (get_cart_contents_total()), ignorando impostos e frete. Para resolver isso, ajustamos a função get_installments para que use get_total('edit'), garantindo que o cálculo do parcelamento agora leva em conta o total completo do pedido, incluindo:

- Subtotal dos produtos
- Frete
- Taxas e impostos aplicáveis