### PR TITLE
Add Dependency Check for Required Plugins with User Notifications

### DIFF
--- a/wc-gateway-braspag.php
+++ b/wc-gateway-braspag.php
@@ -1,20 +1,28 @@
 <?php
 /**
+ * Braspag for WooCommerce Oficial
+ * 
+ * @package           Braspag
+ * @author            Braspag
+ * @copyright         2024 Braspag
+ * @license           GPL-3.0
+ * 
+ * @wordpress-plugin
  * Plugin Name: Braspag for WooCommerce Oficial
  * Plugin URI: https://wordpress.org/plugins/woocommerce-braspag/
  * Description: Take payments on your store using Braspag.
  * Author: Braspag
  * Author URI: https://braspag.com.br/
- * 
  * Version: 2.3.1
- * WP requires at least: 5.3.2
- * WP tested up to: 6.2.2
- * 
+ * Requires at least: 5.3.2
+ * Tested up to: 6.2.2
+ * Requires PHP: 7.0
  * WC requires at least: 4.0.0
  * WC tested up to: 7.9.0
+ * License URI:       https://opensource.org/license/gpl-3/
  * Text Domain: woocommerce-braspag
  * Domain Path: /languages
- *
+ * Requires Plugins: woocommerce, woocommerce-extra-checkout-fields-for-brazil
  */
 
 if (!defined('ABSPATH')) {
@@ -39,14 +47,15 @@ function wc_braspag_missing_wc_notice()
  *
  * @return string
  */
-function wc_braspag_missing_extra_checkout_fields_notice() {
-    echo '<div class="error"><p><strong>' . sprintf(
-        esc_html__(
-            'Braspag requires the Extra Checkout Fields for Brazil plugin to be installed and active. You can download %s here.',
-            'woocommerce-braspag'
-        ),
-        '<a href="https://wordpress.org/plugins/woocommerce-extra-checkout-fields-for-brazil/" target="_blank">Extra Checkout Fields for Brazil</a>'
-    ) . '</strong></p></div>';
+function wc_braspag_missing_extra_checkout_fields_notice()
+{
+	echo '<div class="error"><p><strong>' . sprintf(
+		esc_html__(
+			'Braspag requires the Extra Checkout Fields for Brazil plugin to be installed and active. You can download %s here.',
+			'woocommerce-braspag'
+		),
+		'<a href="https://wordpress.org/plugins/woocommerce-extra-checkout-fields-for-brazil/" target="_blank">Extra Checkout Fields for Brazil</a>'
+	) . '</strong></p></div>';
 }
 
 add_action('plugins_loaded', 'woocommerce_gateway_braspag_init');
@@ -60,11 +69,77 @@ function woocommerce_gateway_braspag_init()
 		return;
 	}
 
-    // Verifica Extra Checkout Fields for Brazil.
-    if (!class_exists('Extra_Checkout_Fields_For_Brazil')) {
-        add_action('admin_notices', 'wc_braspag_missing_extra_checkout_fields_notice');
-        return;
-    }
+	// Verifica Extra Checkout Fields for Brazil.
+	if (!class_exists('Extra_Checkout_Fields_For_Brazil')) {
+		add_action('admin_notices', 'wc_braspag_missing_extra_checkout_fields_notice');
+		return;
+	}
+
+	// Adicionar o código que verifica os plugins obrigatórios
+	add_action(
+		'admin_notices',
+		function () {
+			// Verifica se o usuário tem permissões para instalar plugins
+			$currentUserCanInstallPlugins = current_user_can('install_plugins');
+
+			$minilogo = sprintf('%s%s', plugin_dir_url(__FILE__), 'assets/images/minilogo.png');
+			$translations = [
+				'activate_plugin' => __('Activate %s', 'woocommerce-braspag'),
+				'install_plugin' => __('Install %s', 'woocommerce-braspag'),
+				'see_plugin' => __('See %s', 'woocommerce-braspag'),
+				'miss_plugin' => __('The Braspag module needs an active version of %s in order to work!', 'woocommerce-braspag'),
+			];
+
+			$requiredPlugins = [
+				'WooCommerce' => [
+					'slug' => 'woocommerce',
+					'file' => 'woocommerce/woocommerce.php',
+					'url' => 'https://wordpress.org/plugins/woocommerce/',
+				],
+				'Extra Checkout Fields for Brazil' => [
+					'slug' => 'woocommerce-extra-checkout-fields-for-brazil',
+					'file' => 'woocommerce-extra-checkout-fields-for-brazil/woocommerce-extra-checkout-fields-for-brazil.php',
+					'url' => 'https://wordpress.org/plugins/woocommerce-extra-checkout-fields-for-brazil/',
+				],
+			];
+
+			$allPlugins = function_exists('get_plugins') ? get_plugins() : [];
+
+			foreach ($requiredPlugins as $pluginName => $pluginData) {
+				$isInstalled = !empty($allPlugins[$pluginData['file']]); // Verifica se está instalado
+    			$isActive = is_plugin_active($pluginData['file']); // Verifica se está ativo
+
+				// Define a ação e o link com base no estado do plugin
+				if (!$isInstalled && $currentUserCanInstallPlugins) {
+					// Plugin não está instalado
+					$action = 'install';
+					$link = wp_nonce_url(
+						self_admin_url("update.php?action=install-plugin&plugin={$pluginData['slug']}"),
+						"install-plugin_{$pluginData['slug']}"
+					);
+				} elseif (!$isActive && $isInstalled && $currentUserCanInstallPlugins) {
+					// Plugin está instalado, mas não está ativo
+					$action = 'activate';
+					$link = wp_nonce_url(
+						self_admin_url("plugins.php?action=activate&plugin={$pluginData['file']}&plugin_status=all"),
+						"activate-plugin_{$pluginData['file']}"
+					);
+				} else {
+					// Plugin já está ativo ou não pode ser instalado
+					continue;
+				}
+
+				// Exibe o aviso
+				echo sprintf(
+					'<div class="notice notice-error is-dismissible"><p><img src="%s" style="vertical-align: middle; margin-right: 5px;">%s <a href="%s">%s</a></p></div>',
+					esc_url($minilogo),
+					sprintf(esc_html($translations['miss_plugin']), esc_html($pluginName)),
+					esc_url($link),
+					esc_html($translations["{$action}_plugin"])
+				);
+			}
+		}
+	);
 
 	if (!class_exists('WC_Braspag')):
 		/**

--- a/wc-gateway-braspag.php
+++ b/wc-gateway-braspag.php
@@ -34,6 +34,21 @@ function wc_braspag_missing_wc_notice()
 	echo '<div class="error"><p><strong>' . sprintf(esc_html__('Braspag requires WooCommerce to be installed and active. You can download %s here.', 'woocommerce-braspag'), '<a href="https://woocommerce.com/" target="_blank">WooCommerce</a>') . '</strong></p></div>';
 }
 
+/**
+ * Extra Checkout Fields for Brazil fallback notice.
+ *
+ * @return string
+ */
+function wc_braspag_missing_extra_checkout_fields_notice() {
+    echo '<div class="error"><p><strong>' . sprintf(
+        esc_html__(
+            'Braspag requires the Extra Checkout Fields for Brazil plugin to be installed and active. You can download %s here.',
+            'woocommerce-braspag'
+        ),
+        '<a href="https://wordpress.org/plugins/woocommerce-extra-checkout-fields-for-brazil/" target="_blank">Extra Checkout Fields for Brazil</a>'
+    ) . '</strong></p></div>';
+}
+
 add_action('plugins_loaded', 'woocommerce_gateway_braspag_init');
 
 function woocommerce_gateway_braspag_init()
@@ -44,6 +59,12 @@ function woocommerce_gateway_braspag_init()
 		add_action('admin_notices', 'wc_braspag_missing_wc_notice');
 		return;
 	}
+
+    // Verifica Extra Checkout Fields for Brazil.
+    if (!class_exists('Extra_Checkout_Fields_For_Brazil')) {
+        add_action('admin_notices', 'wc_braspag_missing_extra_checkout_fields_notice');
+        return;
+    }
 
 	if (!class_exists('WC_Braspag')):
 		/**


### PR DESCRIPTION
### Descrição
Esta atualização introduz um recurso para verificar as dependências de plugins necessárias para o sistema e fornece notificações amigáveis ​​quando uma ação é necessária. Se um plugin necessário estiver ausente ou inativo, o usuário verá um aviso com um link para instalar ou ativar o plugin.

### Principais alterações
- Verifica se os plugins `WooCommerce` e `Extra Checkout Fields for Brazil` estão instalados e ativos.
- Exibe notificações acionáveis ​​para plugins ausentes ou inativos.
- Links diretamente para instalar, ativar ou visualizar os plugins necessários para uma experiência de usuário mais suave.

### Por que este recurso?
Isso garante que os usuários sejam informados e orientados a habilitar os plugins necessários, evitando possíveis problemas de funcionalidade.

### Testing
- Funcionalidade verificada com vários estados de plugin (instalado, não instalado, ativo, inativo).
- Notificações e ações testadas com usuários com permissões apropriadas.