### PR TITLE
Compatibilidade com WooCommerce HPOS no Plugin de Pagamento

### DIFF
--- a/includes/admin/class-wc-braspag-privacy.php
+++ b/includes/admin/class-wc-braspag-privacy.php
@@ -118,11 +118,11 @@ class WC_Braspag_Privacy extends WC_Abstract_Privacy
 					'data' => array(
 						array(
 							'name' => __('Braspag payment id', 'woocommerce-braspag'),
-							'value' => get_post_meta($order->get_id(), '_braspag_source_id', true),
+							'value' => $order->get_meta($order->get_id(), '_braspag_source_id', true),
 						),
 						array(
 							'name' => __('Braspag customer id', 'woocommerce-braspag'),
-							'value' => get_post_meta($order->get_id(), '_braspag_customer_id', true),
+							'value' => $order->get_meta($order->get_id(), '_braspag_customer_id', true),
 						),
 					),
 				);
@@ -181,11 +181,11 @@ class WC_Braspag_Privacy extends WC_Abstract_Privacy
 					'data' => array(
 						array(
 							'name' => __('Braspag payment id', 'woocommerce-braspag'),
-							'value' => get_post_meta($subscription->get_id(), '_braspag_source_id', true),
+							'value' => $order->get_meta($subscription->get_id(), '_braspag_source_id', true),
 						),
 						array(
 							'name' => __('Braspag customer id', 'woocommerce-braspag'),
-							'value' => get_post_meta($subscription->get_id(), '_braspag_customer_id', true),
+							'value' => $order->get_meta($subscription->get_id(), '_braspag_customer_id', true),
 						),
 					),
 				);
@@ -325,7 +325,7 @@ class WC_Braspag_Privacy extends WC_Abstract_Privacy
 		$subscription = current(wcs_get_subscriptions_for_order($order->get_id()));
 		$subscription_id = $subscription->get_id();
 
-		$braspag_source_id = get_post_meta($subscription_id, '_braspag_source_id', true);
+		$braspag_source_id = $order->get_meta($subscription_id, '_braspag_source_id', true);
 
 		if (empty($braspag_source_id)) {
 			return array(false, false, array());
@@ -344,14 +344,14 @@ class WC_Braspag_Privacy extends WC_Abstract_Privacy
 		$renewal_orders = WC_Subscriptions_Renewal_Order::get_renewal_orders($order->get_id());
 
 		foreach ($renewal_orders as $renewal_order_id) {
-			delete_post_meta($renewal_order_id, '_braspag_source_id');
-			delete_post_meta($renewal_order_id, '_braspag_refund_id');
-			delete_post_meta($renewal_order_id, '_braspag_customer_id');
+			$order->delete_meta_data($renewal_order_id, '_braspag_source_id');
+			$order->delete_meta_data($renewal_order_id, '_braspag_refund_id');
+			$order->delete_meta_data($renewal_order_id, '_braspag_customer_id');
 		}
 
-		delete_post_meta($subscription_id, '_braspag_source_id');
-		delete_post_meta($subscription_id, '_braspag_refund_id');
-		delete_post_meta($subscription_id, '_braspag_customer_id');
+		$order->delete_meta_data($subscription_id, '_braspag_source_id');
+		$order->delete_meta_data($subscription_id, '_braspag_refund_id');
+		$order->delete_meta_data($subscription_id, '_braspag_customer_id');
 
 		return array(true, false, array(__('Braspag Subscription Data Erased.', 'woocommerce-braspag')));
 	}
@@ -363,9 +363,9 @@ class WC_Braspag_Privacy extends WC_Abstract_Privacy
 	protected function maybe_handle_order($order)
 	{
 		$order_id = $order->get_id();
-		$braspag_source_id = get_post_meta($order_id, '_braspag_source_id', true);
-		$braspag_refund_id = get_post_meta($order_id, '_braspag_refund_id', true);
-		$braspag_customer_id = get_post_meta($order_id, '_braspag_customer_id', true);
+		$braspag_source_id = $order->get_meta($order_id, '_braspag_source_id', true);
+		$braspag_refund_id = $order->get_meta($order_id, '_braspag_refund_id', true);
+		$braspag_customer_id = $order->get_meta($order_id, '_braspag_customer_id', true);
 
 		if (!$this->is_retention_expired($order->get_date_created()->getTimestamp())) {
 			/* translators: %d Order ID */
@@ -376,9 +376,9 @@ class WC_Braspag_Privacy extends WC_Abstract_Privacy
 			return array(false, false, array());
 		}
 
-		delete_post_meta($order_id, '_braspag_source_id');
-		delete_post_meta($order_id, '_braspag_refund_id');
-		delete_post_meta($order_id, '_braspag_customer_id');
+		$order->delete_meta_data($order_id, '_braspag_source_id');
+		$order->delete_meta_data($order_id, '_braspag_refund_id');
+		$order->delete_meta_data($order_id, '_braspag_customer_id');
 
 		return array(true, false, array(__('Braspag personal data erased.', 'woocommerce-braspag')));
 	}

--- a/includes/class-wc-braspag-helper.php
+++ b/includes/class-wc-braspag-helper.php
@@ -22,7 +22,7 @@ class WC_Braspag_Helper
 
 		$order_id = WC_Braspag_Helper::is_wc_lt('3.0') ? $order->id : $order->get_id();
 
-		return WC_Braspag_Helper::is_wc_lt('3.0') ? get_post_meta($order_id, self::META_NAME_BRASPAG_CURRENCY, true) : $order->get_meta(self::META_NAME_BRASPAG_CURRENCY, true);
+		return WC_Braspag_Helper::is_wc_lt('3.0') ? $order->get_meta($order_id, self::META_NAME_BRASPAG_CURRENCY, true) : $order->get_meta(self::META_NAME_BRASPAG_CURRENCY, true);
 	}
 
 	/**
@@ -38,7 +38,7 @@ class WC_Braspag_Helper
 
 		$order_id = WC_Braspag_Helper::is_wc_lt('3.0') ? $order->id : $order->get_id();
 
-		WC_Braspag_Helper::is_wc_lt('3.0') ? update_post_meta($order_id, self::META_NAME_BRASPAG_CURRENCY, $currency) : $order->update_meta_data(self::META_NAME_BRASPAG_CURRENCY, $currency);
+		WC_Braspag_Helper::is_wc_lt('3.0') ? $order = wc_get_order($order_id, self::META_NAME_BRASPAG_CURRENCY, $currency) : $order->update_meta_data(self::META_NAME_BRASPAG_CURRENCY, $currency);
 	}
 
 	/**

--- a/includes/class-wc-braspag-order-handler.php
+++ b/includes/class-wc-braspag-order-handler.php
@@ -77,7 +77,7 @@ class WC_Braspag_Order_Handler extends WC_Braspag_Payment_Gateway
 
         $this->process_braspag_pagador_action_response($response, $order);
 
-        WC_Braspag_Helper::is_wc_lt('3.0') ? update_post_meta($order_id, '_braspag_charge_captured', 'yes') : $order->update_meta_data('_braspag_charge_captured', 'yes');
+        WC_Braspag_Helper::is_wc_lt('3.0') ? $order = wc_get_order($order_id, '_braspag_charge_captured', 'yes') : $order->update_meta_data('_braspag_charge_captured', 'yes');
         $order->save();
 
         return $this;
@@ -164,7 +164,7 @@ class WC_Braspag_Order_Handler extends WC_Braspag_Payment_Gateway
 
         $this->process_braspag_pagador_action_response($response, $order);
 
-        WC_Braspag_Helper::is_wc_lt('3.0') ? update_post_meta($order_id, '_braspag_charge_refunded', 'yes') : $order->update_meta_data('_braspag_charge_refunded', 'yes');
+        WC_Braspag_Helper::is_wc_lt('3.0') ? $order = wc_get_order($order_id, '_braspag_charge_refunded', 'yes') : $order->update_meta_data('_braspag_charge_refunded', 'yes');
         $order->save();
 
         return $this;

--- a/includes/class-wc-gateway-braspag.php
+++ b/includes/class-wc-gateway-braspag.php
@@ -541,7 +541,7 @@ class WC_Gateway_Braspag extends WC_Braspag_Payment_Gateway
         }
 
         // Store charge data.
-        WC_Braspag_Helper::is_wc_lt('3.0') ? update_post_meta($order_id, '_braspag_charge_captured', $captured) : $order->update_meta_data('_braspag_charge_captured', $captured);
+        WC_Braspag_Helper::is_wc_lt('3.0') ? $order = wc_get_order($order_id, '_braspag_charge_captured', $captured) : $order->update_meta_data('_braspag_charge_captured', $captured);
 
         if ('yes' === $captured) {
 
@@ -558,7 +558,7 @@ class WC_Gateway_Braspag extends WC_Braspag_Payment_Gateway
 
             if (in_array($response->body->Payment->Status, ['1', '20'])) {
 
-                WC_Braspag_Helper::is_wc_lt('3.0') ? update_post_meta($order_id, '_transaction_id', $response->body->Payment->PaymentId) : $order->set_transaction_id($response->body->Payment->PaymentId);
+                WC_Braspag_Helper::is_wc_lt('3.0') ? $order = wc_get_order($order_id, '_transaction_id', $response->body->Payment->PaymentId) : $order->set_transaction_id($response->body->Payment->PaymentId);
 
                 $payment_status = 'on-hold';
 
@@ -585,7 +585,7 @@ class WC_Gateway_Braspag extends WC_Braspag_Payment_Gateway
             }
             elseif (in_array($response->body->Payment->Status, ['12'])) {
 
-                WC_Braspag_Helper::is_wc_lt('3.0') ? update_post_meta($order_id, '_transaction_id', $response->body->Payment->PaymentId) : $order->set_transaction_id($response->body->Payment->PaymentId);
+                WC_Braspag_Helper::is_wc_lt('3.0') ? $order = wc_get_order($order_id, '_transaction_id', $response->body->Payment->PaymentId) : $order->set_transaction_id($response->body->Payment->PaymentId);
 
                 /* translators: transaction id */
                 $order->update_status('pending', sprintf(__('Braspag charge pending (Charge ID: %s).', 'woocommerce-braspag'), $response->body->Payment->PaymentId));

--- a/includes/payment-methods/class-wc-gateway-braspag-debitcard.php
+++ b/includes/payment-methods/class-wc-gateway-braspag-debitcard.php
@@ -377,7 +377,7 @@ class WC_Gateway_Braspag_DebitCard extends WC_Gateway_Braspag
 
         if (in_array($response->body->Payment->Status, ['2'])) {
 
-            WC_Braspag_Helper::is_wc_lt('3.0') ? update_post_meta($order_id, '_braspag_charge_captured', 'yes') : $order->update_meta_data('_braspag_charge_captured', 'yes');
+            WC_Braspag_Helper::is_wc_lt('3.0') ? $order = wc_get_order($order_id, '_braspag_charge_captured', 'yes') : $order->update_meta_data('_braspag_charge_captured', 'yes');
 
             $order->payment_complete($response->body->Payment->PaymentId);
 
@@ -387,7 +387,7 @@ class WC_Gateway_Braspag_DebitCard extends WC_Gateway_Braspag
         }
         elseif (in_array($response->body->Payment->Status, ['0', '1', '12'])) {
 
-            WC_Braspag_Helper::is_wc_lt('3.0') ? update_post_meta($order_id, '_transaction_id', $response->body->Payment->PaymentId) : $order->set_transaction_id($response->body->Payment->PaymentId);
+            WC_Braspag_Helper::is_wc_lt('3.0') ? $order = wc_get_order($order_id, '_transaction_id', $response->body->Payment->PaymentId) : $order->set_transaction_id($response->body->Payment->PaymentId);
 
             if ($order->has_status(array('pending', 'failed'))) {
                 WC_Braspag_Helper::is_wc_lt('3.0') ? $order->reduce_order_stock() : wc_reduce_stock_levels($order_id);

--- a/includes/payment-methods/class-wc-gateway-braspag-pix.php
+++ b/includes/payment-methods/class-wc-gateway-braspag-pix.php
@@ -205,7 +205,7 @@ class WC_Gateway_Braspag_Pix extends WC_Gateway_Braspag
            $dataToSave = array_merge($dataToSave, apply_filters('wc_gateway_braspag_pagador_pix_save_payment_response_data', $dataToSave, $order, $response));
 
             foreach ($dataToSave as $key => $value) {
-                update_post_meta($order_id, $key, $value);
+                $order = wc_get_order($order_id, $key, $value);
             }
         }else{
             $dataToSave = array_merge($dataToSave, apply_filters('wc_gateway_braspag_pagador_pix_save_payment_response_data', $dataToSave, $order, $response));

--- a/wc-gateway-braspag.php
+++ b/wc-gateway-braspag.php
@@ -28,6 +28,16 @@ if (!defined('ABSPATH')) {
  *
  * @return string
  */
+
+ add_action('before_woocommerce_init', function(){
+
+    if ( class_exists( \Automattic\WooCommerce\Utilities\FeaturesUtil::class ) ) {
+        \Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility( 'custom_order_tables', __FILE__, true );
+
+    }
+
+});
+
 function wc_braspag_missing_wc_notice()
 {
 	/* translators: 1. URL link. */


### PR DESCRIPTION
Adicionada compatibilidade com o recurso High-Performance Order Storage (HPOS) do WooCommerce. Substituímos todas as interações diretas com o banco de dados pela API CRUD do WooCommerce. Adicionamos uma declaração de compatibilidade com HPOS para o WooCommerce reconhecer o plugin como compatível.