### PR TITLE
Hotfix/delete saved card

### DIFF
--- a/includes/class-wc-braspag-customer.php
+++ b/includes/class-wc-braspag-customer.php
@@ -67,4 +67,23 @@ class WC_Braspag_Customer
 	{
 		update_user_option($this->get_user_id(), '_braspag_customer_id', $id, false);
 	}
+
+	/**
+     * Deleta o recurso associado ao token no sistema Braspag.
+     *
+     * @param string $source_id ID do token/recurso a ser excluído.
+     * @return bool True em caso de sucesso, False em caso de falha.
+     */
+    public function delete_source($source_id) {
+        // TODO Realize a requisição à API da Braspag para excluir o token
+        /*$response = $this->api_request('DELETE', "/tokens/{$source_id}");
+
+        if (isset($response['status']) && $response['status'] === 'success') {
+            return true;
+        }*/
+
+        // Log em caso de falha
+        WC_Braspag_Logger::log("Sem ação para deletar o token {$source_id}: ");
+        return false;
+    }
 }

--- a/includes/class-wc-braspag-payment-tokens.php
+++ b/includes/class-wc-braspag-payment-tokens.php
@@ -59,9 +59,17 @@ class WC_Braspag_Payment_Tokens extends WC_Payment_Tokens
      */
     public function woocommerce_payment_token_deleted($token_id, $token)
     {
-        if ('braspag' === $token->get_gateway_id()) {
-            $braspag_customer = new WC_Braspag_Customer(get_current_user_id());
-            $braspag_customer->delete_source($token->get_token());
+        if ($token && $token->get_gateway_id() === 'braspag') {
+            $customer_id = get_current_user_id();
+            $customer = new WC_Braspag_Customer($customer_id);
+
+            $token = $token->get_token();
+
+            if (method_exists($customer, 'delete_source')) {
+                $customer->delete_source($token);
+            } else {
+                WC_Braspag_Logger::log("O método delete_source() não está implementado na classe WC_Braspag_Customer.");
+            }
         }
     }
 


### PR DESCRIPTION
**Problema Identificado**
Foi reportado que a exclusão de tokens de pagamento estava resultando em um erro crítico devido à ausência do método delete_source() na classe WC_Braspag_Customer. O que causava falhas no funcionamento do Action no painel da minha conta.

**Solução Implementada**
Ausência do Método delete_source()

Foi implementado o método delete_source() na classe WC_Braspag_Customer, para no futuro ser usada para que o token seja excluído corretamente no sistema Braspag durante a exclusão no WooCommerce.
O hook woocommerce_payment_token_deleted foi ajustado para garantir que a exclusão seja tratada adequadamente.

Testes Realizados

- Testes manuais foram realizados para validar:
- A exclusão de tokens.
- Atualização de tokens.
- Criação de tokens.